### PR TITLE
Added authenticatable model class in config file

### DIFF
--- a/config/filament-comments.php
+++ b/config/filament-comments.php
@@ -48,4 +48,9 @@ return [
      * The attribute used to display the user's name.
      */
     'user_name_attribute' => 'name',
+
+    /*
+     * Authenticatable model class
+     */
+    'authenticatable' => \App\Models\User::class,
 ];

--- a/resources/lang/ru/filament-comments.php
+++ b/resources/lang/ru/filament-comments.php
@@ -1,0 +1,13 @@
+<?php
+
+return [
+    'comments' => 'Комментарии',
+    'comments.add' => 'Добавить комментарий',
+    'comments.empty' => 'Комментариев пока нет.',
+    'comments.placeholder' => 'Добавить комментарий...',
+
+    'notifications.created' => 'Комментарий добавлен.',
+    'notifications.deleted' => 'Комментарий удален.',
+
+    'modal.heading' => 'Комментарии',
+];

--- a/resources/lang/uk/filament-comments.php
+++ b/resources/lang/uk/filament-comments.php
@@ -1,0 +1,13 @@
+<?php
+
+return [
+    'comments' => 'Коментарі',
+    'comments.add' => 'Додати коментар',
+    'comments.empty' => 'Поки немає коментарів.',
+    'comments.placeholder' => 'Додати коментар...',
+
+    'notifications.created' => 'Коментар додано.',
+    'notifications.deleted' => 'Коментар видалено.',
+
+    'modal.heading' => 'Коментарі',
+];

--- a/src/Models/FilamentComment.php
+++ b/src/Models/FilamentComment.php
@@ -23,9 +23,9 @@ class FilamentComment extends Model
 
     public function user(): BelongsTo
     {
-        $authenticatable = app(Authenticatable::class);
+        $authenticatable = config('filament-comments.authenticatable');
 
-        return $this->belongsTo($authenticatable::class, 'user_id');
+        return $this->belongsTo($authenticatable, 'user_id');
     }
 
     public function subject(): BelongsTo

--- a/src/Models/FilamentComment.php
+++ b/src/Models/FilamentComment.php
@@ -2,7 +2,6 @@
 
 namespace Parallax\FilamentComments\Models;
 
-use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\MassPrunable;
 use Illuminate\Database\Eloquent\Model;


### PR DESCRIPTION
In case if you use observer on model `FilamentComment` to send email notification with queue like this:
```
class CommentObserver
{
    public function created(FilamentComment $comment): void
    {
        if ($manager = $comment->user->manager) {
            Mail::to($manager)->queue(new CommentMail($comment));
        }
    }
}
```
you will catch an error:
`local.ERROR: Cannot use "::class" on value of type null {"exception":"[object] (TypeError(code: 0): Cannot use \"::class\" on value of type null at .../vendor/parallax/filament-comments/src/Models/FilamentComment.php:28)`.

So, maybe it's better to set up variable `$authenticatable` from config file.