### PR TITLE
Add support for morph maps

### DIFF
--- a/src/Models/Traits/HasFilamentComments.php
+++ b/src/Models/Traits/HasFilamentComments.php
@@ -11,7 +11,7 @@ trait HasFilamentComments
     {
         return $this
             ->hasMany(FilamentComment::class, 'subject_id')
-            ->where('subject_type', static::class)
+            ->where('subject_type', $this->getMorphClass())
             ->latest();
     }
 }


### PR DESCRIPTION
If you define morph maps for the model that you add comments for it will not work. 
This is because you use use `getMorphClass()` to translate the namespaced model name into the mapped name [here](https://github.com/parallax/filament-comments/blob/main/src/Livewire/CommentsComponent.php#L57), but when you query the database for comments you use `static::class`

So if you for example have this:
```
Relation::morphMap([
   'user'           => \App\Models\User::class,
]);
```
you will insert `'user'` into the `subject_type` column, but then you would use `App\Models\User` in the query. 

With this fix, you will use `'user'` in the query as well. 

