### PR TITLE
Hide form option

### DIFF
--- a/resources/views/comments.blade.php
+++ b/resources/views/comments.blade.php
@@ -1,5 +1,6 @@
+@php use Illuminate\Support\Str; @endphp
 <div class="flex flex-col h-full space-y-4">
-    @if (auth()->user()->can('create', \Parallax\FilamentComments\Models\FilamentComment::class))
+    @if (auth()->user()->can('create', \Parallax\FilamentComments\Models\FilamentComment::class) && $this->getConfig()['show_form'] ?? true)
         <div class="space-y-4">
             {{ $this->form }}
             

--- a/src/Infolists/Components/CommentsEntry.php
+++ b/src/Infolists/Components/CommentsEntry.php
@@ -4,9 +4,14 @@ namespace Parallax\FilamentComments\Infolists\Components;
 
 use Filament\Infolists\Components\Entry;
 use Parallax\FilamentComments\Models\FilamentComment;
+use Parallax\FilamentComments\Models\Traits\HasFilamentComments;
+use Parallax\FilamentComments\Models\Traits\HasCommentsConfig;
 
 class CommentsEntry extends Entry
 {
+    use HasFilamentComments;
+    use HasCommentsConfig;
+
     protected string $view = 'filament-comments::component';
 
     protected function setUp(): void

--- a/src/Livewire/CommentsComponent.php
+++ b/src/Livewire/CommentsComponent.php
@@ -11,10 +11,13 @@ use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Model;
 use Livewire\Component;
 use Parallax\FilamentComments\Models\FilamentComment;
+use Parallax\FilamentComments\Models\Traits\HasCommentsConfig;
+use Parallax\FilamentComments\Models\Traits\HasFilamentComments;
 
 class CommentsComponent extends Component implements HasForms
 {
     use InteractsWithForms;
+    use HasCommentsConfig;
 
     public ?array $data = [];
 

--- a/src/Models/Traits/HasCommentsConfig.php
+++ b/src/Models/Traits/HasCommentsConfig.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Parallax\FilamentComments\Models\Traits;
+
+use Illuminate\Support\Facades\Config;
+
+trait HasCommentsConfig
+{
+    protected bool $showForm = true;
+    public array $config;
+
+    public function withoutForm()
+    {
+        $this->showForm = false;
+        
+        return $this;
+    }
+
+    public function getConfig()
+    {
+        $config = Config::get('filament-comments');
+
+        $config['show_form'] = $this->showForm !== false;
+        $config['show_form'] = false;
+
+        return $config;
+    }
+}

--- a/src/Tables/Actions/CommentsAction.php
+++ b/src/Tables/Actions/CommentsAction.php
@@ -7,9 +7,12 @@ use Filament\Support\Enums\MaxWidth;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Model;
 use Parallax\FilamentComments\Models\FilamentComment;
+use Parallax\FilamentComments\Models\Traits\HasFilamentComments;
 
 class CommentsAction extends Action
 {
+    use HasFilamentComments;
+
     public static function getDefaultName(): ?string
     {
         return 'comments';


### PR DESCRIPTION
Like I wrote about in issue #7, I wanted to have the form only in a modal and display the comments in an infolist. I think this UX works better as the infolist should be view/read only and I want it as compact as possible to avoid scrolling. 

This is a working example with the modal as a headerAction on a section:
```
                    Section::make('Admin comments')
                           ->headerActions([
                               Action::make('Add comment')
                                     ->form(function (Form $form, Booking $booking) {
                                         $comments = new CommentsComponent();
                                         $comments->record = $booking;
                                         return $comments->form($form);
                                     })
                                     ->action(function (array $data, Booking $booking): void {
                                         CommentsComponent::macro('fillForm', function ($data) {
                                            $this->form->fill($data);
                                         });
                                         $comments = new CommentsComponent();
                                         $comments->record = $booking;
                                         $comments->fillForm($data);
                                         $comments->create();
                                     })
                               ])
                           ->columnSpanFull()
                           ->schema([
                               CommentsEntry::make('filament_comments')->withoutForm(),
                           ]),
```

It looks like this:
![Screenshot by Dropbox Capture](https://github.com/parallax/filament-comments/assets/680058/e85b1aaf-6a8f-4a1b-9c4d-39ba38791159)

Possible enhancements:
- The comments list does not refresh when you submit a new comment in the modal. You need to refresh the page for the new comment to show up.
- Split the form into it's own component to make this even easier/cleaner to do. It would also be nice with an action that you can use directly, or even a method that returns this whole section. 