### PR TITLE
Eager load user with comments

### DIFF
--- a/src/Livewire/CommentsComponent.php
+++ b/src/Livewire/CommentsComponent.php
@@ -89,7 +89,7 @@ class CommentsComponent extends Component implements HasForms
 
     public function render(): View
     {
-        $comments = $this->record->filamentComments()->latest()->get();
+        $comments = $this->record->filamentComments()->with(['user'])->latest()->get();
 
         return view('filament-comments::comments', ['comments' => $comments]);
     }


### PR DESCRIPTION
Some of us use Model::preventLazyLoading(); in our codebases Service Provider

so the user not being eager loaded cause error. This PR add the eager load of user when comments are loaded for display