### PR TITLE
support markdown editor

### DIFF
--- a/config/filament-comments.php
+++ b/config/filament-comments.php
@@ -27,6 +27,12 @@ return [
      */
     'prune_after_days' => 30,
 
+
+    /*
+     * Options: 'rich', 'markdown'
+     */
+    'editor' => 'rich',
+
     /*
      * The rich editor toolbar buttons that are available to users.
      */

--- a/resources/views/comments.blade.php
+++ b/resources/views/comments.blade.php
@@ -46,7 +46,11 @@
                             </div>
 
                             <div class="prose dark:prose-invert [&>*]:mb-2 [&>*]:mt-0 [&>*:last-child]:mb-0 prose-sm text-sm leading-6 text-gray-950 dark:text-white">
-                                {{ Str::of($comment->comment)->toHtmlString() }}
+                                @if(config('filament-comments.editor') === 'markdown')
+                                    {{ Str::of($comment->comment)->markdown()->toHtmlString() }}
+                                @else
+                                    {{ Str::of($comment->comment)->toHtmlString() }}
+                                @endif
                             </div>
                         </div>
                     </div>

--- a/src/Livewire/CommentsComponent.php
+++ b/src/Livewire/CommentsComponent.php
@@ -31,14 +31,24 @@ class CommentsComponent extends Component implements HasForms
             return $form;
         }
 
+        if (config('filament-comments.editor') === 'markdown') {
+            $editor = Forms\Components\MarkdownEditor::make('comment')
+                ->hiddenLabel()
+                ->required()
+                ->placeholder(__('filament-comments::filament-comments.comments.placeholder'))
+                ->toolbarButtons(config('filament-comments.toolbar_buttons'));
+        } else {
+            $editor = Forms\Components\RichEditor::make('comment')
+                ->hiddenLabel()
+                ->required()
+                ->placeholder(__('filament-comments::filament-comments.comments.placeholder'))
+                ->extraInputAttributes(['style' => 'min-height: 6rem'])
+                ->toolbarButtons(config('filament-comments.toolbar_buttons'));
+        }
+
         return $form
             ->schema([
-                Forms\Components\RichEditor::make('comment')
-                    ->hiddenLabel()
-                    ->required()
-                    ->placeholder(__('filament-comments::filament-comments.comments.placeholder'))
-                    ->extraInputAttributes(['style' => 'min-height: 6rem'])
-                    ->toolbarButtons(config('filament-comments.toolbar_buttons'))
+                $editor,
             ])
             ->statePath('data');
     }


### PR DESCRIPTION
This PR support markdown editor.

It achieves this by adding a new config setting editor. by default it is set to rich but user can change to markdown

Here is a screenshot of how it looks like when editor is markdown mode

![CleanShot 2024-03-24 at 13 49 20](https://github.com/parallax/filament-comments/assets/679513/79b18574-9b7c-417a-9184-6285faab8154)

Some notes:
- The delete icon is not shown because my policy class set delete to false
- From what i see in filament docs, toolbar buttons are pretty much the same for markdown & rich text editor

https://filamentphp.com/docs/3.x/forms/fields/markdown-editor#customizing-the-toolbar-buttons

- I removed `->extraInputAttributes(['style' => 'min-height: 6rem'])` from the MarkdownEditor because MarkdownEditor does not support the ->extraInputAttributes() method