### PR TITLE
Config setting to change model class

### DIFF
--- a/config/filament-comments.php
+++ b/config/filament-comments.php
@@ -15,6 +15,12 @@ return [
         'empty' => 'heroicon-s-chat-bubble-left-right',
     ],
 
+
+    /*
+     * The comment model to be used
+     */
+    'comment_model' => \Parallax\FilamentComments\Models\FilamentComment::class,
+
     /*
      * The policy that will be used to authorize actions against comments.
      */

--- a/src/Actions/CommentsAction.php
+++ b/src/Actions/CommentsAction.php
@@ -29,6 +29,6 @@ class CommentsAction extends Action
             ->modalWidth(MaxWidth::Medium)
             ->modalSubmitAction(false)
             ->modalCancelAction(false)
-            ->visible(fn (): bool => auth()->user()->can('viewAny', FilamentComment::class));
+            ->visible(fn (): bool => auth()->user()->can('viewAny', config('filament-comments.comment_model'));
     }
 }

--- a/src/FilamentCommentsServiceProvider.php
+++ b/src/FilamentCommentsServiceProvider.php
@@ -55,7 +55,7 @@ class FilamentCommentsServiceProvider extends PackageServiceProvider
     {
         Livewire::component('comments', CommentsComponent::class);
 
-        Gate::policy(FilamentComment::class, config('filament-comments.model_policy', FilamentCommentPolicy::class));
+        Gate::policy(config('filament-comments.comment_model'), config('filament-comments.model_policy', FilamentCommentPolicy::class));
 
         FilamentAsset::register(
             $this->getAssets(),

--- a/src/Infolists/Components/CommentsEntry.php
+++ b/src/Infolists/Components/CommentsEntry.php
@@ -13,6 +13,6 @@ class CommentsEntry extends Entry
     {
         parent::setUp();
 
-        $this->visible(fn (): bool => auth()->user()->can('viewAny', FilamentComment::class));
+        $this->visible(fn (): bool => auth()->user()->can('viewAny', config('filament-comments.comment_model')));
     }
 }

--- a/src/Livewire/CommentsComponent.php
+++ b/src/Livewire/CommentsComponent.php
@@ -27,7 +27,7 @@ class CommentsComponent extends Component implements HasForms
 
     public function form(Form $form): Form
     {
-        if (!auth()->user()->can('create', FilamentComment::class)) {
+        if (!auth()->user()->can('create', config('filament-comments.comment_model'))) {
             return $form;
         }
 
@@ -45,7 +45,7 @@ class CommentsComponent extends Component implements HasForms
 
     public function create(): void
     {
-        if (!auth()->user()->can('create', FilamentComment::class)) {
+        if (!auth()->user()->can('create', config('filament-comments.comment_model'))) {
             return;
         }
 

--- a/src/Models/Traits/HasFilamentComments.php
+++ b/src/Models/Traits/HasFilamentComments.php
@@ -10,7 +10,7 @@ trait HasFilamentComments
     public function filamentComments(): HasMany
     {
         return $this
-            ->hasMany(FilamentComment::class, 'subject_id')
+            ->hasMany(config('filament-comments.comment_model'), 'subject_id')
             ->where('subject_type', $this->getMorphClass())
             ->latest();
     }

--- a/src/Tables/Actions/CommentsAction.php
+++ b/src/Tables/Actions/CommentsAction.php
@@ -30,6 +30,6 @@ class CommentsAction extends Action
             ->modalWidth(MaxWidth::Medium)
             ->modalSubmitAction(false)
             ->modalCancelAction(false)
-            ->visible(fn (): bool => auth()->user()->can('viewAny', FilamentComment::class));
+            ->visible(fn (): bool => auth()->user()->can('viewAny', config('filament-comments.comment_model')));
     }
 }


### PR DESCRIPTION
Reason:

In many spatie packages you can change the model class used.

https://github.com/spatie/laravel-medialibrary/blob/main/config/media-library.php

 This allow possibilities such as attaching model events, like for example after a comment is created, I may want to send email notifications

https://laravel.com/docs/11.x/eloquent#events