### PR TITLE
Fix "Call to a member function filamentComments() on null"

### DIFF
--- a/src/Actions/CommentsAction.php
+++ b/src/Actions/CommentsAction.php
@@ -22,7 +22,7 @@ class CommentsAction extends Action
             ->hiddenLabel()
             ->icon(config('filament-comments.icons.action'))
             ->color('gray')
-            ->badge($this->record->filamentComments()->count())
+            ->badge(fn (Model $record): int => $record->filamentComments()->count())
             ->slideOver()
             ->modalContentFooter(fn (): View => view('filament-comments::component'))
             ->modalHeading(__('filament-comments::filament-comments.modal.heading'))


### PR DESCRIPTION
In my instance of Filament, i can't put the action on Pages because it throws a "Call to a member function filamentComments() on null" error, i think the badge function should use injection to retrieve the record at realtime.