### PR TITLE
Wrap tooltip translation in quotation marks

### DIFF
--- a/resources/views/comments.blade.php
+++ b/resources/views/comments.blade.php
@@ -39,7 +39,7 @@
                                             wire:click="delete({{ $comment->id }})"
                                             icon="{{ config('filament-comments.icons.delete') }}"
                                             color="danger"
-                                            tooltip={{ __('filament-comments::filament-comments.comments.delete.tooltip') }}
+                                            tooltip="{{ __('filament-comments::filament-comments.comments.delete.tooltip') }}"
                                         />
                                     </div>
                                 @endif


### PR DESCRIPTION
The delete icon does not appear, needs to have quotation marks.