### PR TITLE
Use Model set in config

### DIFF
--- a/src/Livewire/CommentsComponent.php
+++ b/src/Livewire/CommentsComponent.php
@@ -10,7 +10,6 @@ use Filament\Notifications\Notification;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Model;
 use Livewire\Component;
-use Parallax\FilamentComments\Models\FilamentComment;
 
 class CommentsComponent extends Component implements HasForms
 {
@@ -79,7 +78,7 @@ class CommentsComponent extends Component implements HasForms
 
     public function delete(int $id): void
     {
-        $comment = FilamentComment::find($id);
+        $comment = app(config('filament-comments.comment_model'))::find($id);
 
         if (!$comment) {
             return;


### PR DESCRIPTION
I have created a new `Comment` model within my app so I can use Spaties Activity Log, but the delete method does not use the model define in the config. I have updated this so it does.