### PR TITLE
feat: notify users, config: editor's file uploads disk, security: sanitize raw HTML

### DIFF
--- a/config/filament-comments.php
+++ b/config/filament-comments.php
@@ -57,6 +57,11 @@ return [
     ],
 
     /*
+     * Allow user to select other users to be notified via Filament database notifications.
+     */
+    'notify_users' => true,
+
+    /*
      * The attribute used to display the user's name.
      */
     'user_name_attribute' => 'name',

--- a/config/filament-comments.php
+++ b/config/filament-comments.php
@@ -43,6 +43,7 @@ return [
      * The rich editor toolbar buttons that are available to users.
      */
     'toolbar_buttons' => [
+        'attachFiles',
         'blockquote',
         'bold',
         'bulletList',
@@ -55,6 +56,13 @@ return [
         'underline',
         'undo',
     ],
+
+    /*
+     * The disk on which editor uploads are stored, needs 'attachFiles' to be added to 'toolbar_buttons'.
+     */
+    'editor_disk' => 'public',
+    'editor_directory' => 'comments',
+    'editor_visibility' => 'public',
 
     /*
      * Allow user to select other users to be notified via Filament database notifications.

--- a/resources/lang/de/filament-comments.php
+++ b/resources/lang/de/filament-comments.php
@@ -10,4 +10,8 @@ return [
     'notifications.deleted' => 'Kommentar gelöscht.',
 
     'modal.heading' => 'Kommentare',
+
+    'notify_users.placeholder' => 'Benutzer auswählen, die benachrichtigt werden sollen...',
+    'notify_users.notification_title' => 'Neuer Kommentar von :user',
+    'notify_users.notification_action' => 'Datensatz anzeigen',
 ];

--- a/resources/lang/de/filament-comments.php
+++ b/resources/lang/de/filament-comments.php
@@ -11,6 +11,8 @@ return [
 
     'modal.heading' => 'Kommentare',
 
+    'comments.delete.tooltip' => 'Kommentar löschen',
+
     'notify_users.placeholder' => 'Benutzer auswählen, die benachrichtigt werden sollen...',
     'notify_users.notification_title' => 'Neuer Kommentar von :user',
     'notify_users.notification_action' => 'Datensatz anzeigen',

--- a/resources/lang/en/filament-comments.php
+++ b/resources/lang/en/filament-comments.php
@@ -11,6 +11,8 @@ return [
 
     'modal.heading' => 'Comments',
 
+    'comments.delete.tooltip' => 'Delete comment',
+
     'notify_users.placeholder' => 'Select users to notify...',
     'notify_users.notification_title' => 'New comment from :user',
     'notify_users.notification_action' => 'View record',

--- a/resources/lang/en/filament-comments.php
+++ b/resources/lang/en/filament-comments.php
@@ -11,5 +11,7 @@ return [
 
     'modal.heading' => 'Comments',
 
-    'comments.delete.tooltip' => 'Delete comment'
+    'notify_users.placeholder' => 'Select users to notify...',
+    'notify_users.notification_title' => 'New comment from :user',
+    'notify_users.notification_action' => 'View record',
 ];

--- a/resources/lang/fa/filament-comments.php
+++ b/resources/lang/fa/filament-comments.php
@@ -11,6 +11,8 @@ return [
 
     'modal.heading' => 'نظرات',
 
+    'comments.delete.tooltip' => 'حذف نظر',
+
     'notify_users.placeholder' => 'کاربرانی را انتخاب کنید که مایل به اطلاع رسانی هستند...',
     'notify_users.notification_title' => 'نظر جدید از :user',
     'notify_users.notification_action' => 'مشاهده رکورد',

--- a/resources/lang/fa/filament-comments.php
+++ b/resources/lang/fa/filament-comments.php
@@ -10,4 +10,8 @@ return [
     'notifications.deleted' => 'نظر حذف شد.',
 
     'modal.heading' => 'نظرات',
+
+    'notify_users.placeholder' => 'کاربرانی را انتخاب کنید که مایل به اطلاع رسانی هستند...',
+    'notify_users.notification_title' => 'نظر جدید از :user',
+    'notify_users.notification_action' => 'مشاهده رکورد',
 ];

--- a/resources/lang/fr/filament-comments.php
+++ b/resources/lang/fr/filament-comments.php
@@ -11,6 +11,8 @@ return [
 
     'modal.heading' => 'Commentaires',
 
+    'comments.delete.tooltip' => 'Supprimer le commentaire',
+
     'notify_users.placeholder' => 'Sélectionner les utilisateurs à notifier...',
     'notify_users.notification_title' => 'Nouveau commentaire de :user',
     'notify_users.notification_action' => 'Voir l\'enregistrement',

--- a/resources/lang/fr/filament-comments.php
+++ b/resources/lang/fr/filament-comments.php
@@ -10,4 +10,8 @@ return [
     'notifications.deleted' => 'Commentaire supprimé.',
 
     'modal.heading' => 'Commentaires',
+
+    'notify_users.placeholder' => 'Sélectionner les utilisateurs à notifier...',
+    'notify_users.notification_title' => 'Nouveau commentaire de :user',
+    'notify_users.notification_action' => 'Voir l\'enregistrement',
 ];

--- a/resources/lang/it/filament-comments.php
+++ b/resources/lang/it/filament-comments.php
@@ -11,6 +11,8 @@ return [
 
     'modal.heading' => 'Commenti',
 
+    'comments.delete.tooltip' => 'Cancella commento',
+
     'notify_users.placeholder' => 'Seleziona utenti da notificare...',
     'notify_users.notification_title' => 'Nuovo commento da :user',
     'notify_users.notification_action' => 'Visualizza record',

--- a/resources/lang/it/filament-comments.php
+++ b/resources/lang/it/filament-comments.php
@@ -10,4 +10,8 @@ return [
     'notifications.deleted' => 'Commento cancellato.',
 
     'modal.heading' => 'Commenti',
+
+    'notify_users.placeholder' => 'Seleziona utenti da notificare...',
+    'notify_users.notification_title' => 'Nuovo commento da :user',
+    'notify_users.notification_action' => 'Visualizza record',
 ];

--- a/resources/lang/nl/filament-comments.php
+++ b/resources/lang/nl/filament-comments.php
@@ -10,4 +10,8 @@ return [
     'notifications.deleted' => 'Reactie verwijderd.',
 
     'modal.heading' => 'Reacties',
+
+    'notify_users.placeholder' => 'Selecteer gebruikers om op de hoogte te stellen...',
+    'notify_users.notification_title' => 'Nieuwe reactie van :user',
+    'notify_users.notification_action' => 'Bekijk record',
 ];

--- a/resources/lang/nl/filament-comments.php
+++ b/resources/lang/nl/filament-comments.php
@@ -11,6 +11,8 @@ return [
 
     'modal.heading' => 'Reacties',
 
+    'comments.delete.tooltip' => 'Verwijder reactie',
+
     'notify_users.placeholder' => 'Selecteer gebruikers om op de hoogte te stellen...',
     'notify_users.notification_title' => 'Nieuwe reactie van :user',
     'notify_users.notification_action' => 'Bekijk record',

--- a/resources/lang/no/filament-comments.php
+++ b/resources/lang/no/filament-comments.php
@@ -10,4 +10,8 @@ return [
     'notifications.deleted' => 'Kommentar slettet.',
 
     'modal.heading' => 'Kommentarer',
+
+    'notify_users.placeholder' => 'Velg brukere som skal varsles...',
+    'notify_users.notification_title' => 'Ny kommentar fra :user',
+    'notify_users.notification_action' => 'Se post',
 ];

--- a/resources/lang/no/filament-comments.php
+++ b/resources/lang/no/filament-comments.php
@@ -11,6 +11,8 @@ return [
 
     'modal.heading' => 'Kommentarer',
 
+    'comments.delete.tooltip' => 'Slett kommentar',
+
     'notify_users.placeholder' => 'Velg brukere som skal varsles...',
     'notify_users.notification_title' => 'Ny kommentar fra :user',
     'notify_users.notification_action' => 'Se post',

--- a/resources/lang/pt_BR/filament-comments.php
+++ b/resources/lang/pt_BR/filament-comments.php
@@ -10,4 +10,8 @@ return [
     'notifications.deleted' => 'Comentário deletado.',
 
     'modal.heading' => 'Comentários',
+
+    'notify_users.placeholder' => 'Selecione usuários para notificar...',
+    'notify_users.notification_title' => 'Novo comentário de :user',
+    'notify_users.notification_action' => 'Ver registro',
 ];

--- a/resources/lang/pt_BR/filament-comments.php
+++ b/resources/lang/pt_BR/filament-comments.php
@@ -11,6 +11,8 @@ return [
 
     'modal.heading' => 'Comentários',
 
+    'comments.delete.tooltip' => 'Deletar comentário',
+
     'notify_users.placeholder' => 'Selecione usuários para notificar...',
     'notify_users.notification_title' => 'Novo comentário de :user',
     'notify_users.notification_action' => 'Ver registro',

--- a/resources/lang/ru/filament-comments.php
+++ b/resources/lang/ru/filament-comments.php
@@ -11,6 +11,8 @@ return [
 
     'modal.heading' => 'Комментарии',
 
+    'comments.delete.tooltip' => 'Удалить комментарий',
+
     'notify_users.placeholder' => 'Выберите пользователей для уведомления...',
     'notify_users.notification_title' => 'Новый комментарий от :user',
     'notify_users.notification_action' => 'Просмотреть запись',

--- a/resources/lang/ru/filament-comments.php
+++ b/resources/lang/ru/filament-comments.php
@@ -10,4 +10,8 @@ return [
     'notifications.deleted' => 'Комментарий удален.',
 
     'modal.heading' => 'Комментарии',
+
+    'notify_users.placeholder' => 'Выберите пользователей для уведомления...',
+    'notify_users.notification_title' => 'Новый комментарий от :user',
+    'notify_users.notification_action' => 'Просмотреть запись',
 ];

--- a/resources/lang/uk/filament-comments.php
+++ b/resources/lang/uk/filament-comments.php
@@ -11,6 +11,8 @@ return [
 
     'modal.heading' => 'Коментарі',
 
+    'comments.delete.tooltip' => 'Видалити коментар',
+
     'notify_users.placeholder' => 'Виберіть користувачів для сповіщення...',
     'notify_users.notification_title' => 'Новий коментар від :user',
     'notify_users.notification_action' => 'Переглянути запис',

--- a/resources/lang/uk/filament-comments.php
+++ b/resources/lang/uk/filament-comments.php
@@ -10,4 +10,8 @@ return [
     'notifications.deleted' => 'Коментар видалено.',
 
     'modal.heading' => 'Коментарі',
+
+    'notify_users.placeholder' => 'Виберіть користувачів для сповіщення...',
+    'notify_users.notification_title' => 'Новий коментар від :user',
+    'notify_users.notification_action' => 'Переглянути запис',
 ];

--- a/resources/views/comments.blade.php
+++ b/resources/views/comments.blade.php
@@ -1,5 +1,5 @@
 <div class="flex flex-col h-full space-y-4">
-    @if (auth()->user()->can('create', \Parallax\FilamentComments\Models\FilamentComment::class))
+    @if (auth()->user()->can('create', config('filament-comments.comment_model')))
         <div class="space-y-4">
             {{ $this->form }}
 

--- a/resources/views/comments.blade.php
+++ b/resources/views/comments.blade.php
@@ -2,7 +2,7 @@
     @if (auth()->user()->can('create', \Parallax\FilamentComments\Models\FilamentComment::class))
         <div class="space-y-4">
             {{ $this->form }}
-            
+
             <x-filament::button
                 wire:click="create"
                 color="primary"
@@ -47,9 +47,9 @@
 
                             <div class="prose dark:prose-invert [&>*]:mb-2 [&>*]:mt-0 [&>*:last-child]:mb-0 prose-sm text-sm leading-6 text-gray-950 dark:text-white">
                                 @if(config('filament-comments.editor') === 'markdown')
-                                    {{ Str::of($comment->comment)->markdown()->toHtmlString() }}
+                                    {{ Str::of($comment->comment)->markdown()->sanitizeHtml()->toHtmlString() }}
                                 @else
-                                    {{ Str::of($comment->comment)->toHtmlString() }}
+                                    {{ Str::of($comment->comment)->sanitizeHtml()->toHtmlString() }}
                                 @endif
                             </div>
                         </div>
@@ -63,7 +63,7 @@
                 icon="{{ config('filament-comments.icons.empty') }}"
                 class="h-12 w-12 text-gray-400 dark:text-gray-500"
             />
-            
+
             <div class="text-sm text-gray-400 dark:text-gray-500">
                 {{ __('filament-comments::filament-comments.comments.empty') }}
             </div>

--- a/src/Actions/CommentsAction.php
+++ b/src/Actions/CommentsAction.php
@@ -5,7 +5,6 @@ namespace Parallax\FilamentComments\Actions;
 use Filament\Actions\Action;
 use Filament\Support\Enums\MaxWidth;
 use Illuminate\Contracts\View\View;
-use Parallax\FilamentComments\Models\FilamentComment;
 
 class CommentsAction extends Action
 {

--- a/src/FilamentCommentsServiceProvider.php
+++ b/src/FilamentCommentsServiceProvider.php
@@ -5,15 +5,12 @@ namespace Parallax\FilamentComments;
 use Filament\Support\Assets\Asset;
 use Filament\Support\Assets\Css;
 use Filament\Support\Facades\FilamentAsset;
-use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Gate;
 use Livewire\Livewire;
 use Spatie\LaravelPackageTools\Commands\InstallCommand;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 use Parallax\FilamentComments\Livewire\CommentsComponent;
-use Parallax\FilamentComments\Models\FilamentComment;
-use Parallax\FilamentComments\Policies\FilamentCommentPolicy;
 
 class FilamentCommentsServiceProvider extends PackageServiceProvider
 {
@@ -55,7 +52,7 @@ class FilamentCommentsServiceProvider extends PackageServiceProvider
     {
         Livewire::component('comments', CommentsComponent::class);
 
-        Gate::policy(config('filament-comments.comment_model'), config('filament-comments.model_policy', FilamentCommentPolicy::class));
+        Gate::policy(config('filament-comments.comment_model'), config('filament-comments.model_policy'));
 
         FilamentAsset::register(
             $this->getAssets(),

--- a/src/Infolists/Components/CommentsEntry.php
+++ b/src/Infolists/Components/CommentsEntry.php
@@ -3,7 +3,6 @@
 namespace Parallax\FilamentComments\Infolists\Components;
 
 use Filament\Infolists\Components\Entry;
-use Parallax\FilamentComments\Models\FilamentComment;
 
 class CommentsEntry extends Entry
 {

--- a/src/Livewire/CommentsComponent.php
+++ b/src/Livewire/CommentsComponent.php
@@ -102,7 +102,7 @@ class CommentsComponent extends Component implements HasForms
                 ->label(__('filament-comments::filament-comments.notify_users.notification_action'))
                 ->color('info')
                 ->url(Filament::getResourceUrl($this->record, 'view', ['action' => 'comments']))
-                ->extraAttributes(['wire:click' => '$dispatch(`close-modal`, JSON.parse`{\u0022id\u0022:\u0022database-notifications\u0022}`))'])
+                ->extraAttributes(['wire:click' => '$dispatch(`close-modal`, JSON.parse(`{\u0022id\u0022:\u0022database-notifications\u0022}`))'])
                 ->close();
             Notification::make()
                 ->title($title)

--- a/src/Livewire/CommentsComponent.php
+++ b/src/Livewire/CommentsComponent.php
@@ -36,8 +36,8 @@ class CommentsComponent extends Component implements HasForms
 
         if (config('filament-comments.notify_users')) {
             $users = config('filament-comments.authenticatable')::query()
-                ->where('id', '!=', auth()->id())
-                ->pluck(config('filament-comments.user_name_attribute'), 'id');
+                ->where(auth()->user()->getKeyName(), '!=', auth()->id())
+                ->pluck(config('filament-comments.user_name_attribute'), auth()->user()->getKeyName());
             $schema[] = Forms\Components\Select::make('users_to_notify')
                 ->hiddenLabel()
                 ->placeholder(__('filament-comments::filament-comments.notify_users.placeholder'))

--- a/src/Livewire/CommentsComponent.php
+++ b/src/Livewire/CommentsComponent.php
@@ -100,8 +100,9 @@ class CommentsComponent extends Component implements HasForms
             ]);
             $viewAction = Action::make('view')
                 ->label(__('filament-comments::filament-comments.notify_users.notification_action'))
-                ->url(Filament::getResourceUrl($this->record, 'view'))
                 ->color('info')
+                ->url(Filament::getResourceUrl($this->record, 'view', ['action' => 'comments']))
+                ->dispatch('close-modal', ['id' => 'database-notifications'])
                 ->close();
             Notification::make()
                 ->title($title)

--- a/src/Livewire/CommentsComponent.php
+++ b/src/Livewire/CommentsComponent.php
@@ -102,7 +102,7 @@ class CommentsComponent extends Component implements HasForms
                 ->label(__('filament-comments::filament-comments.notify_users.notification_action'))
                 ->color('info')
                 ->url(Filament::getResourceUrl($this->record, 'view', ['action' => 'comments']))
-                ->dispatch('close-modal', ['id' => 'database-notifications'])
+                ->extraAttributes(['wire:click' => '$dispatch(`close-modal`, JSON.parse`{\u0022id\u0022:\u0022database-notifications\u0022}`))'])
                 ->close();
             Notification::make()
                 ->title($title)

--- a/src/Livewire/CommentsComponent.php
+++ b/src/Livewire/CommentsComponent.php
@@ -12,7 +12,6 @@ use Filament\Notifications\Notification;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Model;
 use Livewire\Component;
-use Parallax\FilamentComments\Models\FilamentComment;
 
 class CommentsComponent extends Component implements HasForms
 {
@@ -120,7 +119,7 @@ class CommentsComponent extends Component implements HasForms
 
     public function delete(int $id): void
     {
-        $comment = FilamentComment::find($id);
+        $comment = config('filament-comments.comment_model')::find($id);
 
         if (!$comment) {
             return;

--- a/src/Livewire/CommentsComponent.php
+++ b/src/Livewire/CommentsComponent.php
@@ -53,14 +53,20 @@ class CommentsComponent extends Component implements HasForms
                 ->hiddenLabel()
                 ->required()
                 ->placeholder(__('filament-comments::filament-comments.comments.placeholder'))
-                ->toolbarButtons(config('filament-comments.toolbar_buttons'));
+                ->toolbarButtons(config('filament-comments.toolbar_buttons'))
+                ->fileAttachmentsDisk(config('filament-comments.editor_disk'))
+                ->fileAttachmentsDirectory(config('filament-comments.editor_directory'))
+                ->fileAttachmentsVisibility(config('filament-comments.editor_visibility'));
         } else {
             $schema[] = Forms\Components\RichEditor::make('comment')
                 ->hiddenLabel()
                 ->required()
                 ->placeholder(__('filament-comments::filament-comments.comments.placeholder'))
                 ->extraInputAttributes(['style' => 'min-height: 6rem'])
-                ->toolbarButtons(config('filament-comments.toolbar_buttons'));
+                ->toolbarButtons(config('filament-comments.toolbar_buttons'))
+                ->fileAttachmentsDisk(config('filament-comments.editor_disk'))
+                ->fileAttachmentsDirectory(config('filament-comments.editor_directory'))
+                ->fileAttachmentsVisibility(config('filament-comments.editor_visibility'));
         }
 
         return $form

--- a/src/Models/Traits/HasFilamentComments.php
+++ b/src/Models/Traits/HasFilamentComments.php
@@ -3,7 +3,6 @@
 namespace Parallax\FilamentComments\Models\Traits;
 
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Parallax\FilamentComments\Models\FilamentComment;
 
 trait HasFilamentComments
 {

--- a/src/Tables/Actions/CommentsAction.php
+++ b/src/Tables/Actions/CommentsAction.php
@@ -6,7 +6,6 @@ use Filament\Tables\Actions\Action;
 use Filament\Support\Enums\MaxWidth;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Model;
-use Parallax\FilamentComments\Models\FilamentComment;
 
 class CommentsAction extends Action
 {


### PR DESCRIPTION
Hi,

New feature to allow user to select other users to be notified via Filament database notifications, with link to the comment's record that auto open the comment modal.

As indicated in [Filament Docs](https://filamentphp.com/docs/3.x/forms/fields/rich-editor#security) the HTML content written by the end-users should be sanitized, i used the same method of filament itself.

Allow the configuration of editor's file uploads disk.