### PR TITLE
Support viewing comments as guest / prevent exceptions

### DIFF
--- a/resources/views/comments.blade.php
+++ b/resources/views/comments.blade.php
@@ -1,5 +1,5 @@
 <div class="flex flex-col h-full space-y-4">
-    @if (auth()->user()->can('create', \Parallax\FilamentComments\Models\FilamentComment::class))
+    @if (auth()->user()?->can('create', \Parallax\FilamentComments\Models\FilamentComment::class))
         <div class="space-y-4">
             {{ $this->form }}
             
@@ -33,7 +33,7 @@
                                     </div>
                                 </div>
 
-                                @if (auth()->user()->can('delete', $comment))
+                                @if (auth()->user()?->can('delete', $comment))
                                     <div class="flex-shrink-0">
                                         <x-filament::icon-button
                                             wire:click="delete({{ $comment->id }})"

--- a/src/Actions/CommentsAction.php
+++ b/src/Actions/CommentsAction.php
@@ -29,6 +29,6 @@ class CommentsAction extends Action
             ->modalWidth(MaxWidth::Medium)
             ->modalSubmitAction(false)
             ->modalCancelAction(false)
-            ->visible(fn (): bool => auth()->user()->can('viewAny', config('filament-comments.comment_model')));
+            ->visible(fn (): bool => auth()->user()?->can('viewAny', config('filament-comments.comment_model')) ?? false);
     }
 }

--- a/src/Infolists/Components/CommentsEntry.php
+++ b/src/Infolists/Components/CommentsEntry.php
@@ -13,6 +13,6 @@ class CommentsEntry extends Entry
     {
         parent::setUp();
 
-        $this->visible(fn (): bool => auth()->user()->can('viewAny', config('filament-comments.comment_model')));
+        $this->visible(fn (): bool => auth()->user()?->can('viewAny', config('filament-comments.comment_model')) ?? false);
     }
 }

--- a/src/Livewire/CommentsComponent.php
+++ b/src/Livewire/CommentsComponent.php
@@ -27,7 +27,7 @@ class CommentsComponent extends Component implements HasForms
 
     public function form(Form $form): Form
     {
-        if (!auth()->user()->can('create', config('filament-comments.comment_model'))) {
+        if (!auth()->user()?->can('create', config('filament-comments.comment_model'))) {
             return $form;
         }
 
@@ -55,7 +55,7 @@ class CommentsComponent extends Component implements HasForms
 
     public function create(): void
     {
-        if (!auth()->user()->can('create', config('filament-comments.comment_model'))) {
+        if (!auth()->user()?->can('create', config('filament-comments.comment_model'))) {
             return;
         }
 
@@ -85,7 +85,7 @@ class CommentsComponent extends Component implements HasForms
             return;
         }
 
-        if (!auth()->user()->can('delete', $comment)) {
+        if (!auth()->user()?->can('delete', $comment)) {
             return;
         }
 

--- a/src/Tables/Actions/CommentsAction.php
+++ b/src/Tables/Actions/CommentsAction.php
@@ -30,6 +30,6 @@ class CommentsAction extends Action
             ->modalWidth(MaxWidth::Medium)
             ->modalSubmitAction(false)
             ->modalCancelAction(false)
-            ->visible(fn (): bool => auth()->user()->can('viewAny', config('filament-comments.comment_model')));
+            ->visible(fn (): bool => auth()->user()?->can('viewAny', config('filament-comments.comment_model')) ?? false);
     }
 }


### PR DESCRIPTION
This PR makes prevents the plugin from throwing exceptions when no user is logged in due to calling `->can()` on `null` as part of the authz checks.

The PR has no impact on merge because the authz checks default to `false`. To actually render the comments for guests the developer has to override the `->visible()` statement on the place of implementation, for example:

```
CommentsEntry::make('filament_comments')
    ->visible(fn (): bool => auth()->user()?->can('viewAny', config('filament-comments.comment_model')) ?? true),
```