### PR TITLE
Update version constraints for Filament v5 and Laravel 13 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,10 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "filament/filament": "^4.0",
+        "php": "^8.2",
+        "filament/filament": "^4.0 | ^5.0",
         "spatie/laravel-package-tools": "^1.15.0",
-        "illuminate/contracts": "^10.0 | ^11.0 | ^12.0"
+        "illuminate/contracts": "^10.0 | ^11.0 | ^12.0 | ^13.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
- Bump PHP minimum to ^8.2 (required by Filament v5)
- Add Filament v5 support (^4.0 | ^5.0)
- Add Laravel 13 support for illuminate/contracts (^10.0 | ^11.0 | ^12.0 | ^13.0)

No code changes needed as Filament v5 has no breaking API changes from v4 (major version bump is solely for Livewire v4 support).

https://claude.ai/code/session_01HAUodcCgeJQ7t8i33JXdU6